### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Jekyll
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: Atlantic Canada Species At Risk Habitat Modelling                        # Title in top navigation bar (navbar) and <head>
 description: A community of practice for habitat modellers in the atlantic region. We are primarily interested in species at risk # Site description in <head>
 author: Atlantic Canada Conservation Data Centre                    # Used for copyright statement in footer
-url: "https://atlantichabitatmodels.github.io/"  # No slash at the end
+url: "https://atlantichabitatmodels.github.io"  # No slash at the end
 baseurl: "/communityofpractice"                 # Only required if your site is on a subdomain e.g. https://username.github.io/sitename
                                         # which has url: "https://username.github.io" (no slash) and baseurl: "/sitename" (leading slash)
                                         # A baseurl affects internal links, see http://peterdesmet.github.io/petridish/about/#links

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,6 +8,7 @@
     href: directory
   - text: Data Directory
     href: https://docs.google.com/spreadsheets/d/1_GZKDpZa18Ga0irokXhh-1ZUyF3TPi0Jl_yG4NrdVlk/edit?usp=sharing
+    new_window: true
   - text: Community Curated Resources
     href: resources
   - text: Logistics Team

--- a/_posts/2022-02-07-peiBirds.md
+++ b/_posts/2022-02-07-peiBirds.md
@@ -1,7 +1,7 @@
 ---
-title: Model Spotlight: Species Distribution Models for three PEI bird Species at Risk
+title: "Model Spotlight: Species Distribution Models for three PEI bird Species at Risk"
 description: Canada Warbler, Olive-sided Flycatcher and Eastern Wood-Pewee
-background: assets/images/patrice-bouchard-Wq0tdsvq5_4-unsplash.jpg
+background: /assets/images/patrice-bouchard-Wq0tdsvq5_4-unsplash.jpg
 author: [Jocelyn Pender]
 categories: [Model Spotlight, SDM, PEI, birds, Species at Risk, Canada Warbler, Olive-sided Flycatcher, Eastern Wood-Pewee]
 comments: true

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -16,11 +16,12 @@ Please join us at our monthly meeting! Contact [jocelyn.pender@accdc.ca](mailto:
 We use email for slow, more in-depth communication. Please join the email list here. You can send emails to the community of practice by emailing [atlantic-habitat-models@googlegroups.com](mailto:atlantic-habitat-models%40googlegroups.com).
 ## Slack
 
- ![Slack logo](https://cdn.iconscout.com/icon/free/png-256/slack-16-722740.png?w=150&h=150&fit=crop){: .rounded .float-left} We use Slack for fast, short communication. Please join the group using this [invite link](https://join.slack.com/t/slack-zqk1710/shared_invite/zt-136t3bedw-kWwHHsXllexK0_H9~x~LZQ).
+![Slack logo](https://cdn.iconscout.com/icon/free/png-256/slack-16-722740.png?w=150&h=150&fit=crop){: .rounded .float-left}
 
- You can sign in to the Slack workspace [here](atlanticcanad-hvq4185.slack.com).
+We use Slack for fast, short communication. Please join the group using this [invite link](https://join.slack.com/t/slack-zqk1710/shared_invite/zt-136t3bedw-kWwHHsXllexK0_H9~x~LZQ).
 
-
+{: .clearfix}
+You can sign in to the Slack workspace [here](atlanticcanad-hvq4185.slack.com).
 
 ## Community directory
 


### PR DESCRIPTION
- Fix blog post by wrapping title in "quotes" (it contains a special character `:` that otherwise breaks the yaml frontmatter
- Fix blog post background image, by linking to `/assets/` not `assets/`
- Have the Google Spreadsheet link in the navigation open in a new tab. Can be reverted.
- Have the `Community` header on contact appear below the slack image
- Ignore local Jekyll files (if you ever want to run the site locally)
- Don't have a trailing slash in the `url` in `_config.yml`